### PR TITLE
Feature: modify accodring to milestone feedback and peer review

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN pip install --no-cache-dir \
     pandas==2.2.0 \
     matplotlib==3.8.3 \
     seaborn==0.13.2 \
-    scikit-learn==1.4.2
+    scikit-learn==1.4.2 \
+    pytest==8.1.1

--- a/Makefile
+++ b/Makefile
@@ -27,15 +27,15 @@ results/eda_boxplot.png: scripts/boxplot_generator.py data/processed/winequality
 	python scripts/boxplot_generator.py --input_file "data/processed/winequality-red-wrangled.csv" --output_file "results/eda_boxplot.png"
 
 # ---------------------------------------------------------
-# 4. MODEL CONFUSION MATRIX
+# 4. MODEL CONFUSION MATRIX & REPORT ARTIFACTS
 # ---------------------------------------------------------
-results/confusion_matrix.png: scripts/confusion_matrix_generator.py data/processed/winequality-red-wrangled.csv
-	python scripts/confusion_matrix_generator.py --input_file "data/processed/winequality-red-wrangled.csv" --output_file "results/confusion_matrix.png"
+results/confusion_matrix.png results/model_metrics.csv results/report_summary.csv: scripts/confusion_matrix_generator.py data/processed/winequality-red-wrangled.csv
+	python scripts/confusion_matrix_generator.py --input_file "data/processed/winequality-red-wrangled.csv" --output_file "results/confusion_matrix.png" --metrics_file "results/model_metrics.csv" --summary_file "results/report_summary.csv"
 
 # ---------------------------------------------------------
 # 5. QUARTO REPORT
 # ---------------------------------------------------------
-report.html: report.qmd results/eda_boxplot.png results/confusion_matrix.png
+report.html: report.qmd results/eda_boxplot.png results/confusion_matrix.png results/model_metrics.csv results/report_summary.csv
 	quarto render report.qmd --to html
 
 # ---------------------------------------------------------
@@ -45,6 +45,7 @@ clean:
 	rm -f data/raw/*.csv
 	rm -f data/processed/*.csv
 	rm -f results/*.png
+	rm -f results/*.csv
 	rm -f report.html
 	rm -rf *_files/
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The project has the following dependencies:
 - matplotlib (3.8.3)
 - seaborn (0.13.2)
 - scikit-learn (1.4.2)
+- pytest (8.1.1)
 - Quarto (1.4.553) (Included in the Docker image)
 
 ## Project Structure & Scripts
@@ -58,7 +59,7 @@ cd dsci-310-group-11
 
 ### 2. Start the Docker Container
 
-First, clone this repository and navigate to its root directory in your terminal. Then, use the command appropriate for your operating system to launch the container and mount the volume:
+Use the command appropriate for your operating system to launch the container and mount the volume:
 
 #### For Mac/Linux (or Git Bash on Windows)
 

--- a/report.qmd
+++ b/report.qmd
@@ -65,6 +65,25 @@ After acquiring the data, we perform data wrangling to frame our predictive ques
 
 ### Exploratory Data Analysis
 
+#### Dataset Variables
+
+The dataset contains 11 physicochemical input features measured from each wine sample, along with one target variable:
+
+| Variable | Description |
+|---|---|
+| `fixed acidity` | Concentration of non-volatile acids (mainly tartaric acid), which contribute to the wine's tartness (g/dm³). |
+| `volatile acidity` | Amount of acetic acid, which at high levels can produce an unpleasant vinegar taste (g/dm³). |
+| `citric acid` | Naturally occurring acid that can add freshness and flavour complexity (g/dm³). |
+| `residual sugar` | Amount of sugar remaining after fermentation; higher values indicate sweeter wines (g/dm³). |
+| `chlorides` | Concentration of salt in the wine (g/dm³). |
+| `free sulfur dioxide` | The free form of SO₂ that prevents microbial growth and oxidation (mg/dm³). |
+| `total sulfur dioxide` | Total amount of SO₂ (free + bound forms); high concentrations can be detected in the nose and taste (mg/dm³). |
+| `density` | Density of the wine, largely influenced by alcohol and sugar content (g/cm³). |
+| `pH` | Describes the acidity or basicity of the wine on a scale of 0 (very acidic) to 14 (very basic). |
+| `sulphates` | A wine additive that contributes to sulfur dioxide levels, acting as an antimicrobial and antioxidant (g/dm³). |
+| `alcohol` | Percentage of alcohol content by volume (% vol). |
+| `quality` | Sensory quality score assigned by wine experts on a scale from 0 to 10 (target variable, binarised to "Good" ≥ 6 / "Bad" < 6). |
+
 We visualize the distribution of alcohol content across "Good" and "Bad" wines. We use a boxplot to compare the groups, which effectively shows the median and spread while avoiding the overplotting issues common in large scatter plots. As shown in @fig-alcohol-boxplot, wines labeled as "Good" generally show higher alcohol content than wines labeled as "Bad" [@waskom2021seaborn].
 
 ![Alcohol content by wine quality label.](results/eda_boxplot.png){#fig-alcohol-boxplot width=70%}

--- a/scripts/confusion_matrix_generator.py
+++ b/scripts/confusion_matrix_generator.py
@@ -9,15 +9,16 @@ from sklearn.metrics import ConfusionMatrixDisplay, classification_report
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from src.model_utils import train_logistic_regression
 
-@click.command
-@click.option('--input_file', type=str, help = "Path (including filename) of where to read data")
-@click.option('--output_file', type=str, help = "Path (including filename) of where to write plot png")
+@click.command()
+@click.option('--input_file', type=str, help="Path (including filename) of where to read data")
+@click.option('--output_file', type=str, help="Path (including filename) of where to write confusion matrix png")
+@click.option('--metrics_file', type=str, default="results/model_metrics.csv", help="Path to write per-class metrics CSV")
+@click.option('--summary_file', type=str, default="results/report_summary.csv", help="Path to write summary statistics CSV")
 
 
-def main(input_file, output_file):
+def main(input_file, output_file, metrics_file, summary_file):
 
-# 1. Prepare features and target
-
+    # 1. Prepare features and target
     data_df = pd.read_csv(input_file, sep=',')
 
     x = data_df.drop(columns=["quality", "label"])
@@ -29,18 +30,41 @@ def main(input_file, output_file):
     )
 
     # 3. Train Logistic Regression
-    lr_model = lr_model = train_logistic_regression(x_train, y_train, max_iter=2000, random_state=123)
+    lr_model = train_logistic_regression(x_train, y_train, max_iter=2000, random_state=123)
 
-    # 4. Show Classification Report
+    # 4. Evaluate and export metrics
     y_pred = lr_model.predict(x_test)
     print(classification_report(y_test, y_pred))
 
-    # 5. Plot Confusion Matrix
+    report_dict = classification_report(y_test, y_pred, output_dict=True)
+
+    metrics_tbl = pd.DataFrame({
+        "class": ["Bad", "Good"],
+        "precision": [report_dict["Bad"]["precision"], report_dict["Good"]["precision"]],
+        "recall": [report_dict["Bad"]["recall"], report_dict["Good"]["recall"]],
+        "f1_score": [report_dict["Bad"]["f1-score"], report_dict["Good"]["f1-score"]],
+        "support": [int(report_dict["Bad"]["support"]), int(report_dict["Good"]["support"])]
+    })
+    Path(metrics_file).parent.mkdir(parents=True, exist_ok=True)
+    metrics_tbl.to_csv(metrics_file, index=False)
+
+    summary_tbl = pd.DataFrame([{
+        "n_rows": int(data_df.shape[0]),
+        "good_count": int((data_df["label"] == "Good").sum()),
+        "bad_count": int((data_df["label"] == "Bad").sum()),
+        "accuracy": float(report_dict["accuracy"]),
+        "good_correct": int(((y_test == "Good") & (y_pred == "Good")).sum()),
+        "bad_correct": int(((y_test == "Bad") & (y_pred == "Bad")).sum())
+    }])
+    Path(summary_file).parent.mkdir(parents=True, exist_ok=True)
+    summary_tbl.to_csv(summary_file, index=False)
+
+    # 5. Plot and save Confusion Matrix
     disp = ConfusionMatrixDisplay.from_estimator(lr_model, x_test, y_test, cmap=plt.cm.Blues)
     plt.title("Confusion Matrix: Logistic Regression")
-    Path(output_file).parent.mkdir(parents=True, exist_ok=True)    
+    Path(output_file).parent.mkdir(parents=True, exist_ok=True)
     plt.savefig(output_file, dpi=300)
 
-    
+
 if __name__ == "__main__":
     main()

--- a/scripts/data_generator.py
+++ b/scripts/data_generator.py
@@ -14,6 +14,7 @@ def main(input_file, output_file):
     df = pd.read_csv(input_file, sep=';')
     print(f"The correct dimensions for red wine data should be: {df.shape}")
 
+    Path(output_file).parent.mkdir(parents=True, exist_ok=True)
     df.to_csv(output_file, index=False)
     print(f"The data has been successfully downloaded and saved to: {output_file}")
 

--- a/scripts/data_processor.py
+++ b/scripts/data_processor.py
@@ -6,7 +6,7 @@ import click
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from src.data_wrangling import generate_quality_label
 
-@click.command
+@click.command()
 @click.option('--input_file', type=str, help = "Path (including filename) of where to read data")
 @click.option('--output_file', type=str, help = "Path (including filename) of where to write datafile")
 
@@ -17,6 +17,7 @@ def main(input_file, output_file):
 
     df_wrangled = generate_quality_label(df, split_threshold)
 
+    Path(output_file).parent.mkdir(parents=True, exist_ok=True)
     df_wrangled.to_csv(output_file, index=False)
 
     print(df_wrangled["label"].value_counts())

--- a/src/data_wrangling.py
+++ b/src/data_wrangling.py
@@ -8,8 +8,8 @@ def generate_quality_label(data, threshold = 6):
     ----------
     data : pandas.DataFrame
         The input DataFrame with 'quality' column for transforming
-    theshold : int, optional
-        Postive integer threshold above which wine will be labelled 'Good'
+    threshold : int, optional
+        Positive integer threshold above which wine will be labelled 'Good'
         
     Returns
     -------
@@ -23,7 +23,7 @@ def generate_quality_label(data, threshold = 6):
     ValueError
         If threshold is negative
     TypeError
-        If threshold is not a integer.
+        If threshold is not an integer.
     TypeError
         If df is not a pandas DataFrame.
     

--- a/src/model_utils.py
+++ b/src/model_utils.py
@@ -2,6 +2,7 @@
 
 from sklearn.linear_model import LogisticRegression
 import pandas as pd
+import numpy as np
 
 def train_logistic_regression(x_train, y_train, max_iter=2000, random_state=None):
     """
@@ -15,7 +16,7 @@ def train_logistic_regression(x_train, y_train, max_iter=2000, random_state=None
         The target labels for training.
     max_iter : int, optional
         Maximum number of iterations taken for the solvers to converge, by default 2000.
-    random_state : int, optional
+    random_state : int or None, optional
         Used when shuffling the data, by default None.    
         
     Returns
@@ -25,11 +26,41 @@ def train_logistic_regression(x_train, y_train, max_iter=2000, random_state=None
         
     Raises
     ------
+    TypeError
+        If x_train is not a pandas DataFrame or numpy ndarray.
+    TypeError
+        If y_train is not a pandas Series or numpy ndarray.
+    TypeError
+        If max_iter is not an integer.
+    TypeError
+        If random_state is not an integer or None.
     ValueError
-        If the number of samples in X_train and y_train do not match.
+        If x_train or y_train is empty.
+    ValueError
+        If max_iter is not a positive integer.
+    ValueError
+        If the number of samples in x_train and y_train do not match.
     """
+    if not isinstance(x_train, (pd.DataFrame, np.ndarray)):
+        raise TypeError("x_train must be a pandas DataFrame or numpy ndarray.")
+
+    if not isinstance(y_train, (pd.Series, np.ndarray)):
+        raise TypeError("y_train must be a pandas Series or numpy ndarray.")
+
+    if not isinstance(max_iter, int):
+        raise TypeError("max_iter must be an integer.")
+
+    if random_state is not None and not isinstance(random_state, int):
+        raise TypeError("random_state must be an integer or None.")
+
+    if len(x_train) == 0 or len(y_train) == 0:
+        raise ValueError("x_train and y_train must not be empty.")
+
+    if max_iter <= 0:
+        raise ValueError("max_iter must be a positive integer.")
+
     if len(x_train) != len(y_train):
-        raise ValueError("X_train and y_train must have the same number of rows.")
+        raise ValueError("x_train and y_train must have the same number of rows.")
     
     model = LogisticRegression(max_iter=max_iter, random_state=random_state)
     model.fit(x_train, y_train)

--- a/src/predict_wine_quality.ipynb
+++ b/src/predict_wine_quality.ipynb
@@ -28,7 +28,7 @@
     "## Introduction\n",
     "\n",
     "### Background\n",
-    "Wine certification and quality assessment are crucial elements in the wine industry, traditionally relying heavily on human sensory evaluations by wine experts (sommeliers). However, human taste can be subjective. The objective physicochemical properties of wine—such as its acidity, residual sugar, chlorides, and alcohol content—are the fundamental chemical building blocks that determine its final taste and quality. Understanding the relationship between these chemical components and the perceived quality can help automate quality control and provide actionable insights for winemakers.\n",
+    "Wine certification and quality assessment are crucial elements in the wine industry, traditionally relying heavily on human sensory evaluations by wine experts (sommeliers). However, human taste can be subjective. The objective physicochemical properties of wine\u2014such as its acidity, residual sugar, chlorides, and alcohol content\u2014are the fundamental chemical building blocks that determine its final taste and quality. Understanding the relationship between these chemical components and the perceived quality can help automate quality control and provide actionable insights for winemakers.\n",
     "\n",
     "### Predictive Question\n",
     "In this project, we ask the following predictive question: **Can we accurately predict whether a red wine will be classified as \"Good\" (having a sensory quality score of 6 or higher) based purely on its objective physicochemical properties?**\n",
@@ -401,51 +401,6 @@
     "plt.title(\"Confusion Matrix: Logistic Regression\")\n",
     "plt.savefig(\"../results/confusion_matrix.png\", dpi=300)\n",
     "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2794ffc8",
-   "metadata": {},
-   "source": [
-    "### Exporting Report Artifacts for Quarto\n",
-    "To support the final Quarto report, we save important results from the analysis in separate files. This includes a table of model results and a summary file with values such as the number of observations, the number of \"Good\" and \"Bad\" wines, the model accuracy, and the number of correct predictions. These files are then used in the Quarto report so the text, tables, and figures update automatically based on the analysis."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fcf9c79d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pathlib import Path\n",
-    "import pandas as pd\n",
-    "from sklearn.metrics import classification_report\n",
-    "\n",
-    "results_dir = Path(\"../results\")\n",
-    "results_dir.mkdir(parents=True, exist_ok=True)\n",
-    "\n",
-    "report_dict = classification_report(y_test, y_pred, output_dict=True)\n",
-    "\n",
-    "metrics_tbl = pd.DataFrame({\n",
-    "    \"class\": [\"Bad\", \"Good\"],\n",
-    "    \"precision\": [report_dict[\"Bad\"][\"precision\"], report_dict[\"Good\"][\"precision\"]],\n",
-    "    \"recall\": [report_dict[\"Bad\"][\"recall\"], report_dict[\"Good\"][\"recall\"]],\n",
-    "    \"f1_score\": [report_dict[\"Bad\"][\"f1-score\"], report_dict[\"Good\"][\"f1-score\"]],\n",
-    "    \"support\": [int(report_dict[\"Bad\"][\"support\"]), int(report_dict[\"Good\"][\"support\"])]\n",
-    "})\n",
-    "metrics_tbl.to_csv(results_dir / \"model_metrics.csv\", index=False)\n",
-    "\n",
-    "summary_tbl = pd.DataFrame([{\n",
-    "    \"n_rows\": int(df_wrangled.shape[0]),\n",
-    "    \"good_count\": int((df_wrangled[\"label\"] == \"Good\").sum()),\n",
-    "    \"bad_count\": int((df_wrangled[\"label\"] == \"Bad\").sum()),\n",
-    "    \"accuracy\": float(report_dict[\"accuracy\"]),\n",
-    "    \"good_correct\": int(((y_test == \"Good\") & (y_pred == \"Good\")).sum()),\n",
-    "    \"bad_correct\": int(((y_test == \"Bad\") & (y_pred == \"Bad\")).sum())\n",
-    "}])\n",
-    "summary_tbl.to_csv(results_dir / \"report_summary.csv\", index=False)\n"
    ]
   },
   {

--- a/test/test_data_wrangling.py
+++ b/test/test_data_wrangling.py
@@ -7,6 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from src.data_wrangling import generate_quality_label
 
 def test_data_wrangling_success():
+    """Test that generate_quality_label returns a DataFrame with correct labels using the default threshold of 6."""
     raw_data = pd.DataFrame({'quality': [3,7,5,3,9,8]})
 
     wrangled_data = generate_quality_label(raw_data, 6)
@@ -14,6 +15,7 @@ def test_data_wrangling_success():
     assert list(wrangled_data["label"]) == ["Bad", "Good", "Bad", "Bad", "Good", "Good"]
 
 def test_data_wrangling_success_diff_threshold():
+    """Test that generate_quality_label correctly re-labels wines when a non-default threshold is supplied."""
     raw_data = pd.DataFrame({'quality': [3,7,5,3,9,8]})
 
     wrangled_data = generate_quality_label(raw_data, 4)


### PR DESCRIPTION
## Summary of Changes

This PR addresses feedback from Milestone 2, 3, and peer review.

### Milestone 3 Feedback

- **Input validation** (`src/model_utils.py`): Added type checks (`x_train`, `y_train`, `max_iter`, `random_state`), empty data checks, and positive value check for `max_iter` to `train_logistic_regression()`.
- **Docstring fixes** (`src/data_wrangling.py`): Corrected spelling errors in `generate_quality_label()` docstring (`theshold` → `threshold`, `Postive` → `Positive`, `a integer` → `an integer`).
- **Test documentation** (`test/test_data_wrangling.py`): Added missing docstrings to `test_data_wrangling_success` and `test_data_wrangling_success_diff_threshold`.
- **README** (`README.md`): Removed redundant "clone this repository" sentence in Step 2 (Step 1 already covers this).

### Peer Review Feedback

- **Variable descriptions** (`report.qmd`): Added a "Dataset Variables" table to the EDA section describing all 11 physicochemical features and the target variable.
- **pytest in Docker** (`Dockerfile`): Added `pytest==8.1.1` so `python -m pytest` runs correctly inside the container.
- **Notebook cleanup** (`src/predict_wine_quality.ipynb`): Removed the "Exporting Report Artifacts for Quarto" section (cells that saved CSVs). This logic has been moved into `scripts/confusion_matrix_generator.py` as a proper script with `--metrics_file` and `--summary_file` CLI options.
- **Makefile** (`Makefile`): Updated to pass the new CSV output paths to `confusion_matrix_generator.py` and added `model_metrics.csv` / `report_summary.csv` as explicit dependencies of `report.html`.

### Bug Fixes

- **`scripts/data_processor.py`**: Fixed missing parentheses on `@click.command()` and added automatic output directory creation.
- **`scripts/data_generator.py`**: Added automatic output directory creation so `make all` works correctly after `make clean`.

Fix issue #38 